### PR TITLE
Allow retrieving slices of the PE with an FP

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@ mod utility;
 use std::mem::{transmute,size_of};
 
 use types::*;
-use utility::{FP,RefSafe,URP,URPConvert,FPRef};
-pub use utility::{RVA,CChar,Error,Result,AsOsStr};
+use utility::{RefSafe,URP,URPConvert,FPRef};
+pub use utility::{FP,RVA,CChar,Error,Result,AsOsStr};
 
 #[cfg(target_endian="big")] const E:ENDIANNESS_NOT_SUPPORTED=();
 
@@ -172,7 +172,19 @@ impl<'data> Pe<'data> {
 	pub fn ref_cstr_at(&self, rva: RVA<[CChar]>) -> Result<&'data [CChar]> {
 		let mut max_len=0;
 		let fp=try!(self.resolve_rva_raw(rva+0u32,0,Some(&mut max_len)));
-		self.data.ref_cstr_at(fp.offset(0),max_len)
+		self.data.ref_cstr_at(fp.offset(0),Some(max_len))
+	}
+
+	pub fn ref_at_fp<T: RefSafe>(&self, fp: FP<T>) -> Result<&'data T> {
+		self.data.ref_at(fp)
+	}
+
+	pub fn ref_slice_at_fp<T: RefSafe>(&self, fp: FP<[T]>, count: u32) -> Result<&'data [T]> {
+		self.data.ref_slice_at(fp,count)
+	}
+
+	pub fn ref_cstr_at_fp(&self, fp: FP<[CChar]>) -> Result<&'data [CChar]> {
+		self.data.ref_cstr_at(fp,None)
 	}
 
 	pub fn ref_pe_header(&self) -> Result<&'data [u8]> {

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -201,7 +201,7 @@ impl From<IoError> for Error {
 pub trait FPRef<'data> {
 	fn ref_at<T: RefSafe>(&'data self, fp: FP<T>) -> Result<&'data T>;
 	fn ref_slice_at<T: RefSafe>(&'data self, fp: FP<[T]>, count: u32) -> Result<&'data [T]>;
-	fn ref_cstr_at(&'data self, fp: FP<[CChar]>, maxlen: u32) -> Result<&'data [CChar]>;
+	fn ref_cstr_at(&'data self, fp: FP<[CChar]>, maxlen: Option<u32>) -> Result<&'data [CChar]>;
 }
 
 impl<'data> FPRef<'data> for [u8] {
@@ -225,11 +225,10 @@ impl<'data> FPRef<'data> for [u8] {
 		}
 	}
 
-	fn ref_cstr_at(&'data self, fp: FP<[CChar]>, maxlen: u32) -> Result<&'data [CChar]> {
-		let mut data=&self[fp.get() as usize..];
-		if (maxlen as usize)<data.len() {
-			data=&data[..maxlen as usize];
-		}
+	fn ref_cstr_at(&'data self, fp: FP<[CChar]>, maxlen: Option<u32>) -> Result<&'data [CChar]> {
+		let start = fp.get() as usize;
+		let end = maxlen.map(|len| start + len as usize).unwrap_or(self.len());
+		let data=&self[start..end];
 		let cstr=unsafe{transmute::<&[u8],&[CChar]>(data)};
 		match cstr.null_terminated() {
 			None => Err(IoError::new(IoErrorKind::UnexpectedEof,"could not find NULL terminator").into()),


### PR DESCRIPTION
Analogous to `ref_at` and `ref_slice_at` for RVA.
