### PR TITLE
Change Pe::get_directory to use a special trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pe"
 description = "Portable Executable (PE) parsing library"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Jethro Beekman <jethro@jbeekman.nl>"]
 license = "GPL-2.0+"
 repository = "https://github.com/jethrogb/pe-rs"

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -157,7 +157,7 @@ unsafe impl Size4Bytes for u32 {}
 unsafe impl Size4Bytes for i32 {}
 
 // This trait must only be implemented by types without pointers/references!
-pub unsafe trait RefSafe {}
+pub unsafe trait RefSafe: Sized {}
 
 unsafe impl RefSafe for u8 {}
 unsafe impl RefSafe for u16 {}


### PR DESCRIPTION
I didn't like the way `Pe::get_directory` was super generic.

@aidanhs Can you double check if these changes work with your usecase?
